### PR TITLE
Handle split line items using the `split` attribute

### DIFF
--- a/src/UnitsHelper.js
+++ b/src/UnitsHelper.js
@@ -61,7 +61,10 @@ export default class UnitsHelper {
 
   static perAcreCost = (product, item, acres) => {
     const perUnitCost = UnitsHelper.perUnitCost(product, item);
-    const acresRatio = _.toNumber(item.applied_acres) / acres;
+    let acresRatio = 1;
+    if (item.split) {
+      acresRatio = _.toNumber(item.applied_acres) / acres;
+    }
     if (item.is_total) {
       const total = item.amount * perUnitCost;
       return total / acres;

--- a/test/UnitsHelper.test.js
+++ b/test/UnitsHelper.test.js
@@ -221,7 +221,7 @@ describe('UnitsHelper', () => {
 
     it('should calculate per acre costs from a given product, input applied to half the field', () => {
       const product = productInCustomUnits;
-      const lineItem = lineIteminCustomUnits;
+      const lineItem = { ...lineIteminCustomUnits, split: true };
       const unitCost = UnitsHelper.perAcreCost(product, lineItem, 200);
       expect(unitCost).toBeCloseTo(2000.00);
     });


### PR DESCRIPTION
Handles `split` line items in a more useful way.

We only treat the line item as `split` if the line item has the attribute `split`. The previous behaviors could cause errors when the line item wasn't `split`, and somehow, the acres changed, and the line item did not reflect the new applied acres.