### PR TITLE
Ensure math is exported from unit package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
 import UnitsHelper from './UnitsHelper';
+import math from './Math';
+
+export { math };
 
 export default UnitsHelper;


### PR DESCRIPTION
Exports `math` from the main package, so our custom defined units (just seed and bushels) can be used.